### PR TITLE
pass encoding UTF-8 due to: https://bugs.launchpad.net/lxml/+bug/1873306

### DIFF
--- a/json2marc21/json2marcxml.py
+++ b/json2marc21/json2marcxml.py
@@ -60,7 +60,8 @@ def record_to_xml_node(record, quiet=False, namespace=False):
                 data_subfield.set("code", subfield[0])
                 data_subfield.text = translate(subfield[1])
 
-    return ET.tostring(root)
+    # pass UTF-8 - encoding due to: https://bugs.launchpad.net/lxml/+bug/1873306
+    return ET.tostring(root, encoding="UTF-8")
 
 
 def main():


### PR DESCRIPTION
Some Saxorum-Personen-Daten - records, containing cjk - han characters, lead lxml to fail with "lxml.etree.SerialisationError: IO_ENCODER ERROR". 
Related sample record:  curl -XGET --header 'Content-Type: application/json' http://sdvlodpro.slub-dresden.de:9200/gnd_marc21/_search\?size\=1 -d '{"query" : {"match" : {"001": "120444322X"}}}'