### PR TITLE
fix for "unexpected keyword argument 'encoding'"

### DIFF
--- a/json2marc21/json2marc21.py
+++ b/json2marc21/json2marc21.py
@@ -49,7 +49,7 @@ def transpose_to_marc21(record, fix_xml):
 def main():
     for line in sys.stdin:
         try:
-            record = json.loads(line, encoding='utf-8')
+            record = json.loads(line)
             record = transpose_to_marc21(record, False)
             sys.stdout.buffer.write(record.as_marc())
             sys.stdout.flush()

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name='pymarc2jsonl',
           'argparse>=1.4.0',
           'pymarc>=4.0.0',
           'six>=1.14.0',
+          'lxml>=4.8.0',
           'es2json>=0.0.1'
       ],
       python_requires=">=3.6.*",


### PR DESCRIPTION
Willy hit the "unexpected keyword argument 'encoding'" exception when running json2marc21.py on python >=3.9. The argument "encoding" is deprecated and ignored since python 3.1 (https://docs.python.org/3.1/library/json.html#json.loads) it was removed with python 3.9 (https://docs.python.org/3.9/library/json.html#json.loads).